### PR TITLE
Consistent returns for `rouge_n` and `rouge_l`

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .rouge import GeRouge


### PR DESCRIPTION
**Disclaimer:** This PR is introducing breaking changes compared to the current version.

This PR contains some minor clean-up related to my previous suggestions (basically removing any unused objects in line with PEP-8). On top of that, I noticed that the functions `rouge_n` and `rouge_l` had different return parameters, which makes it hard to plot the actual results when comparing to "other ROUGE scores".
I also added some minor docstrings to these two functions, since they are probably what most people would use from the library.

Both functions now return consistent tuples of `(precision, recall, F1)` (note that the order is different from your original implementation, which returns `(F1, recall, precision)` for `rouge_l`).

Since I don't know in what ways you are currently using these functions, feel free to ignore this PR, since I don't want to break existing projects utilizing this.